### PR TITLE
IDP-1088 - Improved regex

### DIFF
--- a/.github/workflows/reusable-jira-workflow.yml
+++ b/.github/workflows/reusable-jira-workflow.yml
@@ -27,7 +27,7 @@ jobs:
               throw "Branch name ${{ inputs.branch_name }} doesn't respect the required pattern ([a-zA-Z]+[_-][0-9]+). A valid branch name example would be: feature/IDP-123"
             }
 
-            $JiraIssueKey = $Matches[0] -replace '/', ''
+            $JiraIssueKey = $Matches[0]
             $PWord = ConvertTo-SecureString -String "${{ secrets.JIRA_API_TOKEN }}" -AsPlainText -Force
             $Credential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList "${{ secrets.JIRA_USERNAME }}", $PWord
 

--- a/.github/workflows/reusable-jira-workflow.yml
+++ b/.github/workflows/reusable-jira-workflow.yml
@@ -22,7 +22,7 @@ jobs:
             }
 
             Set-JiraConfigServer -Server "${{ secrets.JIRA_URL }}"
-            if("${{ inputs.branch_name }}" -match "\/[a-zA-Z]+[_-][0-9]+" -eq $False)
+            if("${{ inputs.branch_name }}" -match "(?<=\/)[a-zA-Z]+[_-][0-9]+" -eq $False)
             {
               throw "Branch name ${{ inputs.branch_name }} doesn't respect the required pattern ([a-zA-Z]+[_-][0-9]+). A valid branch name example would be: feature/IDP-123"
             }

--- a/.github/workflows/reusable-jira-workflow.yml
+++ b/.github/workflows/reusable-jira-workflow.yml
@@ -22,12 +22,12 @@ jobs:
             }
 
             Set-JiraConfigServer -Server "${{ secrets.JIRA_URL }}"
-            if("${{ inputs.branch_name }}" -match "[a-zA-Z]+[_-][0-9]+" -eq $False)
+            if("${{ inputs.branch_name }}" -match "\/[a-zA-Z]+[_-][0-9]+" -eq $False)
             {
               throw "Branch name ${{ inputs.branch_name }} doesn't respect the required pattern ([a-zA-Z]+[_-][0-9]+). A valid branch name example would be: feature/IDP-123"
             }
 
-            $JiraIssueKey = $Matches[0]
+            $JiraIssueKey = $Matches[0] -replace '/', ''
             $PWord = ConvertTo-SecureString -String "${{ secrets.JIRA_API_TOKEN }}" -AsPlainText -Force
             $Credential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList "${{ secrets.JIRA_USERNAME }}", $PWord
 


### PR DESCRIPTION
I should now be able to handle automated revert pull requests created from Github which usually have this kind of format

`revert-91-feature/idp-0987`

Currently `revert-91`  would be the first match in the array of matches