### PR TITLE
IDP-1498 - Fix linearB workflows for outside orgs

### DIFF
--- a/.github/workflows/linearb-deployment.yml
+++ b/.github/workflows/linearb-deployment.yml
@@ -8,7 +8,7 @@ on:
         type: string
     secrets:
       LINEARB_APIKEY:
-        required: false
+        required: true
 
 jobs:
   main:

--- a/.github/workflows/linearb-deployment.yml
+++ b/.github/workflows/linearb-deployment.yml
@@ -6,6 +6,9 @@ on:
       environment:
         required: true
         type: string
+    secrets:
+      LINEARB_APIKEY:
+        required: false
 
 jobs:
   main:


### PR DESCRIPTION
## Context 
It seems that orgs other than gsoft-inc using this workflow cannot leverage the secrets inherit feature and have to pass in the secret directly to the workflow.

## Description
Added the LINEARB_APIKEY as a defined secret as per the documentation [here](https://docs.github.com/en/actions/using-workflows/reusing-workflows#using-inputs-and-secrets-in-a-reusable-workflow) 

The secret being required doesn't break current usage where secrets are inherited, I tested it.

## Breaking changes
No, should work the same for current usage