### PR TITLE
Give content read permissions to semgrep pipeline

### DIFF
--- a/.github/workflows/reusable-semgrep-workflow.yml
+++ b/.github/workflows/reusable-semgrep-workflow.yml
@@ -7,6 +7,7 @@ jobs:
   semgrep:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       security-events: write
 
     container:


### PR DESCRIPTION
Give content read permissions to semgrep pipeline. This is necessary when we are using semgrep in a private/internal repository, 