### PR TITLE
IDP-2183 Re-enable renovate autodiscover

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,11 @@
 {
-    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-    "extends": [
-      "github>gsoft-inc/renovate-config"
-    ]
-  }
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Discovers all repositories within the gsoft-inc organisation that contains a Renovate configuration file, and execute Renovate by using each individual repository configuration",
+  "autodiscover": true,
+  "autodiscoverFilter": ["gsoft-inc/*"],
+  "optimizeForDisabled": true,
+  "onboarding": false,
+  "extends": [
+    "github>gsoft-inc/renovate-config"
+  ]
+}


### PR DESCRIPTION
The diff in https://github.com/gsoft-inc/wl-reusable-workflows/commit/63d6459e3917c8d179f94eb1e46c16c7ce9bacd9 removed autodiscover so our renovate is just not working at all since last week :/