### PR TITLE
IDP-2279 Succeed workflow after committing fixes

### DIFF
--- a/.github/workflows/terraform-on-branch-push.yml
+++ b/.github/workflows/terraform-on-branch-push.yml
@@ -20,16 +20,17 @@ jobs:
           output-file: README.md
           output-method: inject
       - name: Check for unstaged changes
+        id: git-check
         run: |
-          sudo chown -R runner:docker .git
-          git add . && git diff --quiet && git diff --cached --quiet
+          git add **/*.md **/*.tf **/*.tfvars
+          git diff --staged --exit-code || echo "changes=true" >> $GITHUB_OUTPUT
       - name: Commit and Push changes
-        if: failure()
+        if: steps.git-check.outputs.changes == 'true'
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git add .
-          git commit -m "chore: format terraform code"
+          git add **/*.md **/*.tf **/*.tfvars
+          git commit -m "chore: format terraform code and update docs"
           git push
   tflint:
     runs-on: ubuntu-latest

--- a/.github/workflows/terraform-on-branch-push.yml
+++ b/.github/workflows/terraform-on-branch-push.yml
@@ -22,14 +22,14 @@ jobs:
       - name: Check for unstaged changes
         id: git-check
         run: |
-          git add \*.md \*.tf \*.tfvars
+          git add --ignore-missing \*.md \*.tf \*.tfvars
           git diff --staged --exit-code || echo "changes=true" >> $GITHUB_OUTPUT
       - name: Commit and Push changes
         if: steps.git-check.outputs.changes == 'true'
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git add \*.md \*.tf \*.tfvars
+          git add --ignore-missing \*.md \*.tf \*.tfvars
           git commit -m "chore: format terraform code and update docs"
           git push
   tflint:

--- a/.github/workflows/terraform-on-branch-push.yml
+++ b/.github/workflows/terraform-on-branch-push.yml
@@ -22,14 +22,14 @@ jobs:
       - name: Check for unstaged changes
         id: git-check
         run: |
-          git add **/*.md **/*.tf **/*.tfvars
+          git add \*.md \*.tf \*.tfvars
           git diff --staged --exit-code || echo "changes=true" >> $GITHUB_OUTPUT
       - name: Commit and Push changes
         if: steps.git-check.outputs.changes == 'true'
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git add **/*.md **/*.tf **/*.tfvars
+          git add \*.md \*.tf \*.tfvars
           git commit -m "chore: format terraform code and update docs"
           git push
   tflint:

--- a/.github/workflows/terraform-on-branch-push.yml
+++ b/.github/workflows/terraform-on-branch-push.yml
@@ -22,14 +22,13 @@ jobs:
       - name: Check for unstaged changes
         id: git-check
         run: |
-          git add --ignore-missing \*.md \*.tf \*.tfvars
+          find . -type f \( -name '*.md' -o -name '*.tf' -o -name '*.tfvars' \) -exec git add {} +
           git diff --staged --exit-code || echo "changes=true" >> $GITHUB_OUTPUT
       - name: Commit and Push changes
         if: steps.git-check.outputs.changes == 'true'
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git add --ignore-missing \*.md \*.tf \*.tfvars
           git commit -m "chore: format terraform code and update docs"
           git push
   tflint:


### PR DESCRIPTION
Previously, we used a failure code as flow control in the workflow, resulting in the need to re-run the workflow after changes are committed to confirm that the formatting is good. This pattern is discouraged by GitHub, so we'll just mark the check successful right away and save some time and CPU cycles in the process.

Also limits the files committed by this workflow to just the files we expect it to modify for additional safety.