### PR TITLE
IDP-2284 Use github action to increment tag versions on merge

### DIFF
--- a/.github/workflows/terraform-create-git-tag.yml
+++ b/.github/workflows/terraform-create-git-tag.yml
@@ -12,22 +12,26 @@ on:
         type: string
 
 jobs:
-  create_tag:
+  build:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
-
-    env:
-      GIT_USER_NAME: "Infra Workleap"
-      GIT_USER_EMAIL: "infra@workleap.com"
-      SOURCE_VERSION_MESSAGE: "Automated tag creation"
-
+    permissions:
+      contents: write
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+    - uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.pull_request.merge_commit_sha }}
+        fetch-depth: '0'
 
-      - name: Create Git Tag
-        run: |
-          echo "Creating tag [${buildVersion}] with message: ${{ env.SOURCE_VERSION_MESSAGE }}"
-          git config --global user.name "${{ env.GIT_USER_NAME }}"
-          git config --global user.email "${{ env.GIT_USER_EMAIL }}"
-          git tag -a ${buildVersion} -m "${{ env.SOURCE_VERSION_MESSAGE }}"
-          git push origin --tags
+    - name: Set git author
+      run: |
+        git config --global user.name "github-actions[bot]"
+        git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+    - name: Bump version and push tag
+      uses: anothrNick/github-tag-action@v1 # Don't use @master or @v1 unless you're happy to test the latest version
+      env:
+        DEFAULT_BUMP: patch
+        INITIAL_VERSION: 1.0.0
+        WITH_V: false
+        PRERELEASE: false


### PR DESCRIPTION
Makes use of https://github.com/marketplace/actions/github-tag-bump.

The strategy replicates what we have on ADO: automatically increment `patch` numbers.

We can instruct the workflow to increment `minor` or `major` versions in the merge commit message.