### PR TITLE
IDP-2284 Be more specific about action version pin

### DIFF
--- a/.github/workflows/terraform-create-git-tag.yml
+++ b/.github/workflows/terraform-create-git-tag.yml
@@ -29,7 +29,7 @@ jobs:
         git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
     - name: Bump version and push tag
-      uses: anothrNick/github-tag-action@v1 # Don't use @master or @v1 unless you're happy to test the latest version
+      uses: anothrNick/github-tag-action@v1.71.0
       env:
         DEFAULT_BUMP: patch
         INITIAL_VERSION: 1.0.0


### PR DESCRIPTION
To pin the action tags to digest shas, I think we should use this renovate setting: https://github.com/renovatebot/renovate/issues/11987 in our renovate config, wdyt @asimmon?