### PR TITLE
Use workleap infra pat to commit formatting

### DIFF
--- a/.github/workflows/terraform-on-branch-push.yml
+++ b/.github/workflows/terraform-on-branch-push.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.WORKLEAP_INFRA_PAT }}
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
       - name: Terraform Format


### PR DESCRIPTION
Use a PAT to trigger new workflow runs on formatting changes, to prevent the Cortex YAML linter from letting failed checks pass.