### PR TITLE
Update github-tag-action version

### DIFF
--- a/.github/workflows/terraform-create-git-tag.yml
+++ b/.github/workflows/terraform-create-git-tag.yml
@@ -21,7 +21,7 @@ jobs:
         git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
     - name: Bump version and push tag
-      uses: anothrNick/github-tag-action@v1.71.0
+      uses: anothrNick/github-tag-action@1.71.0
       env:
         GITHUB_TOKEN: ${{ github.token }}
         DEFAULT_BUMP: patch


### PR DESCRIPTION
It looks like the `v` suffix has vanished upstream??